### PR TITLE
Fix mismatched_lifetime_syntaxes warnings

### DIFF
--- a/codegen/src/codegen_helper/templates/complete.rs
+++ b/codegen/src/codegen_helper/templates/complete.rs
@@ -19,7 +19,7 @@ impl CODERSTRUCT {
     /// assert_eq!(CODERSTRUCT.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
 
@@ -37,7 +37,7 @@ impl CODERSTRUCT {
     /// assert!(matches!(CODERSTRUCT.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
 
@@ -53,7 +53,7 @@ impl CODERSTRUCT {
     /// assert_eq!(CODERSTRUCT.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/codegen/src/codegen_helper/templates/incomplete.rs
+++ b/codegen/src/codegen_helper/templates/incomplete.rs
@@ -19,7 +19,7 @@ impl CODERSTRUCT {
     /// assert_eq!(CODERSTRUCT.decode(&[116, 101, 120, 116]).unwrap(), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Result<Cow<str>, DecodeError> {
+    pub fn decode(self, bytes: &[u8]) -> Result<Cow<'_, str>, DecodeError> {
         decode_helper(&DECODE_TABLE, bytes, None)
     }
 
@@ -35,7 +35,7 @@ impl CODERSTRUCT {
     /// assert_eq!(CODERSTRUCT.decode_lossy(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some('�')).unwrap()
     }
 
@@ -54,7 +54,7 @@ impl CODERSTRUCT {
     /// assert_eq!(CODERSTRUCT.decode_lossy_fallback(&[116, 101, 120, 116], '�'), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<str> {
+    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some(fallback)).unwrap()
     }
 
@@ -72,7 +72,7 @@ impl CODERSTRUCT {
     /// assert!(matches!(CODERSTRUCT.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
 
@@ -88,7 +88,7 @@ impl CODERSTRUCT {
     /// assert_eq!(CODERSTRUCT.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp1250.rs
+++ b/src/code_pages/cp1250.rs
@@ -18,7 +18,7 @@ impl CP1250 {
     /// assert_eq!(CP1250.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP1250 byte-encoding
@@ -35,7 +35,7 @@ impl CP1250 {
     /// assert!(matches!(CP1250.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP1250 byte-encoding
@@ -50,7 +50,7 @@ impl CP1250 {
     /// assert_eq!(CP1250.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp1251.rs
+++ b/src/code_pages/cp1251.rs
@@ -18,7 +18,7 @@ impl CP1251 {
     /// assert_eq!(CP1251.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP1251 byte-encoding
@@ -35,7 +35,7 @@ impl CP1251 {
     /// assert!(matches!(CP1251.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP1251 byte-encoding
@@ -50,7 +50,7 @@ impl CP1251 {
     /// assert_eq!(CP1251.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp1252.rs
+++ b/src/code_pages/cp1252.rs
@@ -18,7 +18,7 @@ impl CP1252 {
     /// assert_eq!(CP1252.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP1252 byte-encoding
@@ -35,7 +35,7 @@ impl CP1252 {
     /// assert!(matches!(CP1252.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP1252 byte-encoding
@@ -50,7 +50,7 @@ impl CP1252 {
     /// assert_eq!(CP1252.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp1253.rs
+++ b/src/code_pages/cp1253.rs
@@ -18,7 +18,7 @@ impl CP1253 {
     /// assert_eq!(CP1253.decode(&[116, 101, 120, 116]).unwrap(), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Result<Cow<str>, DecodeError> {
+    pub fn decode(self, bytes: &[u8]) -> Result<Cow<'_, str>, DecodeError> {
         decode_helper(&DECODE_TABLE, bytes, None)
     }
     /// Decode CP1253 byte-encoding into UTF-8 string
@@ -33,7 +33,7 @@ impl CP1253 {
     /// assert_eq!(CP1253.decode_lossy(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some('�')).unwrap()
     }
     /// Decode CP1253 byte-encoding into UTF-8 string
@@ -51,7 +51,7 @@ impl CP1253 {
     /// assert_eq!(CP1253.decode_lossy_fallback(&[116, 101, 120, 116], '�'), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<str> {
+    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some(fallback)).unwrap()
     }
     /// Encode UTF-8 string into CP1253 byte-encoding
@@ -68,7 +68,7 @@ impl CP1253 {
     /// assert!(matches!(CP1253.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP1253 byte-encoding
@@ -83,7 +83,7 @@ impl CP1253 {
     /// assert_eq!(CP1253.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp1254.rs
+++ b/src/code_pages/cp1254.rs
@@ -18,7 +18,7 @@ impl CP1254 {
     /// assert_eq!(CP1254.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP1254 byte-encoding
@@ -35,7 +35,7 @@ impl CP1254 {
     /// assert!(matches!(CP1254.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP1254 byte-encoding
@@ -50,7 +50,7 @@ impl CP1254 {
     /// assert_eq!(CP1254.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp1255.rs
+++ b/src/code_pages/cp1255.rs
@@ -18,7 +18,7 @@ impl CP1255 {
     /// assert_eq!(CP1255.decode(&[116, 101, 120, 116]).unwrap(), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Result<Cow<str>, DecodeError> {
+    pub fn decode(self, bytes: &[u8]) -> Result<Cow<'_, str>, DecodeError> {
         decode_helper(&DECODE_TABLE, bytes, None)
     }
     /// Decode CP1255 byte-encoding into UTF-8 string
@@ -33,7 +33,7 @@ impl CP1255 {
     /// assert_eq!(CP1255.decode_lossy(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some('�')).unwrap()
     }
     /// Decode CP1255 byte-encoding into UTF-8 string
@@ -51,7 +51,7 @@ impl CP1255 {
     /// assert_eq!(CP1255.decode_lossy_fallback(&[116, 101, 120, 116], '�'), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<str> {
+    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some(fallback)).unwrap()
     }
     /// Encode UTF-8 string into CP1255 byte-encoding
@@ -68,7 +68,7 @@ impl CP1255 {
     /// assert!(matches!(CP1255.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP1255 byte-encoding
@@ -83,7 +83,7 @@ impl CP1255 {
     /// assert_eq!(CP1255.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp1256.rs
+++ b/src/code_pages/cp1256.rs
@@ -18,7 +18,7 @@ impl CP1256 {
     /// assert_eq!(CP1256.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP1256 byte-encoding
@@ -35,7 +35,7 @@ impl CP1256 {
     /// assert!(matches!(CP1256.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP1256 byte-encoding
@@ -50,7 +50,7 @@ impl CP1256 {
     /// assert_eq!(CP1256.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp1257.rs
+++ b/src/code_pages/cp1257.rs
@@ -18,7 +18,7 @@ impl CP1257 {
     /// assert_eq!(CP1257.decode(&[116, 101, 120, 116]).unwrap(), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Result<Cow<str>, DecodeError> {
+    pub fn decode(self, bytes: &[u8]) -> Result<Cow<'_, str>, DecodeError> {
         decode_helper(&DECODE_TABLE, bytes, None)
     }
     /// Decode CP1257 byte-encoding into UTF-8 string
@@ -33,7 +33,7 @@ impl CP1257 {
     /// assert_eq!(CP1257.decode_lossy(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some('�')).unwrap()
     }
     /// Decode CP1257 byte-encoding into UTF-8 string
@@ -51,7 +51,7 @@ impl CP1257 {
     /// assert_eq!(CP1257.decode_lossy_fallback(&[116, 101, 120, 116], '�'), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<str> {
+    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some(fallback)).unwrap()
     }
     /// Encode UTF-8 string into CP1257 byte-encoding
@@ -68,7 +68,7 @@ impl CP1257 {
     /// assert!(matches!(CP1257.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP1257 byte-encoding
@@ -83,7 +83,7 @@ impl CP1257 {
     /// assert_eq!(CP1257.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp1258.rs
+++ b/src/code_pages/cp1258.rs
@@ -18,7 +18,7 @@ impl CP1258 {
     /// assert_eq!(CP1258.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP1258 byte-encoding
@@ -35,7 +35,7 @@ impl CP1258 {
     /// assert!(matches!(CP1258.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP1258 byte-encoding
@@ -50,7 +50,7 @@ impl CP1258 {
     /// assert_eq!(CP1258.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp437.rs
+++ b/src/code_pages/cp437.rs
@@ -18,7 +18,7 @@ impl CP437 {
     /// assert_eq!(CP437.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP437 byte-encoding
@@ -35,7 +35,7 @@ impl CP437 {
     /// assert!(matches!(CP437.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP437 byte-encoding
@@ -50,7 +50,7 @@ impl CP437 {
     /// assert_eq!(CP437.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp737.rs
+++ b/src/code_pages/cp737.rs
@@ -18,7 +18,7 @@ impl CP737 {
     /// assert_eq!(CP737.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP737 byte-encoding
@@ -35,7 +35,7 @@ impl CP737 {
     /// assert!(matches!(CP737.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP737 byte-encoding
@@ -50,7 +50,7 @@ impl CP737 {
     /// assert_eq!(CP737.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp850.rs
+++ b/src/code_pages/cp850.rs
@@ -18,7 +18,7 @@ impl CP850 {
     /// assert_eq!(CP850.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP850 byte-encoding
@@ -35,7 +35,7 @@ impl CP850 {
     /// assert!(matches!(CP850.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP850 byte-encoding
@@ -50,7 +50,7 @@ impl CP850 {
     /// assert_eq!(CP850.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp852.rs
+++ b/src/code_pages/cp852.rs
@@ -18,7 +18,7 @@ impl CP852 {
     /// assert_eq!(CP852.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP852 byte-encoding
@@ -35,7 +35,7 @@ impl CP852 {
     /// assert!(matches!(CP852.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP852 byte-encoding
@@ -50,7 +50,7 @@ impl CP852 {
     /// assert_eq!(CP852.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp855.rs
+++ b/src/code_pages/cp855.rs
@@ -18,7 +18,7 @@ impl CP855 {
     /// assert_eq!(CP855.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP855 byte-encoding
@@ -35,7 +35,7 @@ impl CP855 {
     /// assert!(matches!(CP855.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP855 byte-encoding
@@ -50,7 +50,7 @@ impl CP855 {
     /// assert_eq!(CP855.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp857.rs
+++ b/src/code_pages/cp857.rs
@@ -18,7 +18,7 @@ impl CP857 {
     /// assert_eq!(CP857.decode(&[116, 101, 120, 116]).unwrap(), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Result<Cow<str>, DecodeError> {
+    pub fn decode(self, bytes: &[u8]) -> Result<Cow<'_, str>, DecodeError> {
         decode_helper(&DECODE_TABLE, bytes, None)
     }
     /// Decode CP857 byte-encoding into UTF-8 string
@@ -33,7 +33,7 @@ impl CP857 {
     /// assert_eq!(CP857.decode_lossy(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some('�')).unwrap()
     }
     /// Decode CP857 byte-encoding into UTF-8 string
@@ -51,7 +51,7 @@ impl CP857 {
     /// assert_eq!(CP857.decode_lossy_fallback(&[116, 101, 120, 116], '�'), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<str> {
+    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some(fallback)).unwrap()
     }
     /// Encode UTF-8 string into CP857 byte-encoding
@@ -68,7 +68,7 @@ impl CP857 {
     /// assert!(matches!(CP857.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP857 byte-encoding
@@ -83,7 +83,7 @@ impl CP857 {
     /// assert_eq!(CP857.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp860.rs
+++ b/src/code_pages/cp860.rs
@@ -18,7 +18,7 @@ impl CP860 {
     /// assert_eq!(CP860.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP860 byte-encoding
@@ -35,7 +35,7 @@ impl CP860 {
     /// assert!(matches!(CP860.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP860 byte-encoding
@@ -50,7 +50,7 @@ impl CP860 {
     /// assert_eq!(CP860.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp861.rs
+++ b/src/code_pages/cp861.rs
@@ -18,7 +18,7 @@ impl CP861 {
     /// assert_eq!(CP861.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP861 byte-encoding
@@ -35,7 +35,7 @@ impl CP861 {
     /// assert!(matches!(CP861.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP861 byte-encoding
@@ -50,7 +50,7 @@ impl CP861 {
     /// assert_eq!(CP861.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp862.rs
+++ b/src/code_pages/cp862.rs
@@ -18,7 +18,7 @@ impl CP862 {
     /// assert_eq!(CP862.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP862 byte-encoding
@@ -35,7 +35,7 @@ impl CP862 {
     /// assert!(matches!(CP862.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP862 byte-encoding
@@ -50,7 +50,7 @@ impl CP862 {
     /// assert_eq!(CP862.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp863.rs
+++ b/src/code_pages/cp863.rs
@@ -18,7 +18,7 @@ impl CP863 {
     /// assert_eq!(CP863.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP863 byte-encoding
@@ -35,7 +35,7 @@ impl CP863 {
     /// assert!(matches!(CP863.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP863 byte-encoding
@@ -50,7 +50,7 @@ impl CP863 {
     /// assert_eq!(CP863.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp864.rs
+++ b/src/code_pages/cp864.rs
@@ -18,7 +18,7 @@ impl CP864 {
     /// assert_eq!(CP864.decode(&[116, 101, 120, 116]).unwrap(), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Result<Cow<str>, DecodeError> {
+    pub fn decode(self, bytes: &[u8]) -> Result<Cow<'_, str>, DecodeError> {
         decode_helper_non_ascii(&DECODE_TABLE, bytes, None)
     }
     /// Decode CP864 byte-encoding into UTF-8 string
@@ -33,7 +33,7 @@ impl CP864 {
     /// assert_eq!(CP864.decode_lossy(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper_non_ascii(&DECODE_TABLE, bytes, Some('�')).unwrap()
     }
     /// Decode CP864 byte-encoding into UTF-8 string
@@ -51,7 +51,7 @@ impl CP864 {
     /// assert_eq!(CP864.decode_lossy_fallback(&[116, 101, 120, 116], '�'), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<str> {
+    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<'_, str> {
         decode_helper_non_ascii(&DECODE_TABLE, bytes, Some(fallback)).unwrap()
     }
     /// Encode UTF-8 string into CP864 byte-encoding
@@ -68,7 +68,7 @@ impl CP864 {
     /// assert!(matches!(CP864.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP864 byte-encoding
@@ -83,7 +83,7 @@ impl CP864 {
     /// assert_eq!(CP864.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp865.rs
+++ b/src/code_pages/cp865.rs
@@ -18,7 +18,7 @@ impl CP865 {
     /// assert_eq!(CP865.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP865 byte-encoding
@@ -35,7 +35,7 @@ impl CP865 {
     /// assert!(matches!(CP865.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP865 byte-encoding
@@ -50,7 +50,7 @@ impl CP865 {
     /// assert_eq!(CP865.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp866.rs
+++ b/src/code_pages/cp866.rs
@@ -18,7 +18,7 @@ impl CP866 {
     /// assert_eq!(CP866.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP866 byte-encoding
@@ -35,7 +35,7 @@ impl CP866 {
     /// assert!(matches!(CP866.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP866 byte-encoding
@@ -50,7 +50,7 @@ impl CP866 {
     /// assert_eq!(CP866.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp869.rs
+++ b/src/code_pages/cp869.rs
@@ -18,7 +18,7 @@ impl CP869 {
     /// assert_eq!(CP869.decode(&[116, 101, 120, 116]).unwrap(), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Result<Cow<str>, DecodeError> {
+    pub fn decode(self, bytes: &[u8]) -> Result<Cow<'_, str>, DecodeError> {
         decode_helper(&DECODE_TABLE, bytes, None)
     }
     /// Decode CP869 byte-encoding into UTF-8 string
@@ -33,7 +33,7 @@ impl CP869 {
     /// assert_eq!(CP869.decode_lossy(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some('�')).unwrap()
     }
     /// Decode CP869 byte-encoding into UTF-8 string
@@ -51,7 +51,7 @@ impl CP869 {
     /// assert_eq!(CP869.decode_lossy_fallback(&[116, 101, 120, 116], '�'), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<str> {
+    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some(fallback)).unwrap()
     }
     /// Encode UTF-8 string into CP869 byte-encoding
@@ -68,7 +68,7 @@ impl CP869 {
     /// assert!(matches!(CP869.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP869 byte-encoding
@@ -83,7 +83,7 @@ impl CP869 {
     /// assert_eq!(CP869.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp874.rs
+++ b/src/code_pages/cp874.rs
@@ -18,7 +18,7 @@ impl CP874 {
     /// assert_eq!(CP874.decode(&[116, 101, 120, 116]).unwrap(), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Result<Cow<str>, DecodeError> {
+    pub fn decode(self, bytes: &[u8]) -> Result<Cow<'_, str>, DecodeError> {
         decode_helper(&DECODE_TABLE, bytes, None)
     }
     /// Decode CP874 byte-encoding into UTF-8 string
@@ -33,7 +33,7 @@ impl CP874 {
     /// assert_eq!(CP874.decode_lossy(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode_lossy(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some('�')).unwrap()
     }
     /// Decode CP874 byte-encoding into UTF-8 string
@@ -51,7 +51,7 @@ impl CP874 {
     /// assert_eq!(CP874.decode_lossy_fallback(&[116, 101, 120, 116], '�'), "text");
     /// ```
     #[inline(always)]
-    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<str> {
+    pub fn decode_lossy_fallback(self, bytes: &[u8], fallback: char) -> Cow<'_, str> {
         decode_helper(&DECODE_TABLE, bytes, Some(fallback)).unwrap()
     }
     /// Encode UTF-8 string into CP874 byte-encoding
@@ -68,7 +68,7 @@ impl CP874 {
     /// assert!(matches!(CP874.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP874 byte-encoding
@@ -83,7 +83,7 @@ impl CP874 {
     /// assert_eq!(CP874.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }

--- a/src/code_pages/cp910.rs
+++ b/src/code_pages/cp910.rs
@@ -18,7 +18,7 @@ impl CP910 {
     /// assert_eq!(CP910.decode(&[116, 101, 120, 116]), "text");
     /// ```
     #[inline(always)]
-    pub fn decode(self, bytes: &[u8]) -> Cow<str> {
+    pub fn decode(self, bytes: &[u8]) -> Cow<'_, str> {
         decode_helper_non_ascii(&DECODE_TABLE, bytes)
     }
     /// Encode UTF-8 string into CP910 byte-encoding
@@ -35,7 +35,7 @@ impl CP910 {
     /// assert!(matches!(CP910.encode("text 🦀"), EncodeError));
     /// ```
     #[inline(always)]
-    pub fn encode(self, s: &str) -> Result<Cow<[u8]>, EncodeError> {
+    pub fn encode(self, s: &str) -> Result<Cow<'_, [u8]>, EncodeError> {
         self.encode_helper(s, None)
     }
     /// Encode UTF-8 string into CP910 byte-encoding
@@ -50,7 +50,7 @@ impl CP910 {
     /// assert_eq!(CP910.encode_lossy("text 🦀", 168), vec![116, 101, 120, 116, 32, 168]);
     /// ```
     #[inline(always)]
-    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<[u8]> {
+    pub fn encode_lossy(self, s: &str, fallback: u8) -> Cow<'_, [u8]> {
         self.encode_helper(s, Some(fallback)).unwrap()
     }
 }


### PR DESCRIPTION
## Summary
- Add explicit `'_` lifetime annotations to `Cow` return types in codegen templates
- Fixes 89 compiler warnings about elided lifetimes being used inconsistently

## Test plan
- [x] `cargo build` compiles with no warnings
- [x] `cargo test` passes (95 tests)
- [x] `cargo fuzz run invariant` runs without crashes