### PR TITLE
Add ci-success job for branch protection

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,3 +44,17 @@ jobs:
         run: |
           cd fuzz
           nix develop --command cargo fuzz run invariant -- -max_total_time=60
+
+  # Final job that depends on all other jobs - use this in branch protection rules
+  ci-success:
+    runs-on: ubuntu-latest
+    needs: [build-and-test, fuzz]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ needs.build-and-test.result }}" != "success" || "${{ needs.fuzz.result }}" != "success" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi
+          echo "All jobs passed"


### PR DESCRIPTION
## Summary
- Add a `ci-success` job that depends on all CI jobs (`build-and-test`, `fuzz`)
- This provides a single status check to require in branch protection rules
- Uses `if: always()` to ensure it runs even when dependencies fail

## Test plan
- [ ] Verify CI runs all jobs and `ci-success` reports correctly
- [ ] Configure branch protection to require `ci-success` check