### PR TITLE
Disable FlakeHub in CI cache action

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
 
       - name: Build
         run: nix develop --command cargo build --verbose
@@ -34,6 +36,8 @@ jobs:
 
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
 
       - name: Fuzz validate target
         run: |
@@ -55,6 +59,8 @@ jobs:
 
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
 
       - name: Run codegen
         run: |


### PR DESCRIPTION
## Summary
- Disable FlakeHub cache in magic-nix-cache-action to silence authentication warnings
- GitHub Actions native cache continues to work for caching Nix store paths

## Context
The CI was showing warnings about FlakeHub authentication failures. Since we don't use FlakeHub Cache (which is a paid feature), this change explicitly disables it while keeping the free GitHub Actions cache working.