### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-01-10
+- Improve `decode_lossy` performance by 1.5-2x for incomplete codepages using dual-table approach
+
 ## [1.2.0] - 2025-01-07
 - Remove unsafe code from encoder while improving encoding performance by ~40% for mostly-ASCII inputs
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yore"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Andreas Liljeqvist <bonega@gmail.com>"]
 edition = "2021"
 categories = ["encoding"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Rust library for decoding and encoding character sets based on OEM code pages.
 
-[![yore at crates.io](https://img.shields.io/badge/crates.io-1.2.0-blue)](https://crates.io/crates/yore)
+[![yore at crates.io](https://img.shields.io/badge/crates.io-1.3.0-blue)](https://crates.io/crates/yore)
 [![yore at docs.rs](https://docs.rs/yore/badge.svg)](https://docs.rs/yore)
 
 # Features
@@ -18,7 +18,7 @@ Add `yore` to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-yore = "1.2.0"
+yore = "1.3.0"
 ```
 
 # Examples


### PR DESCRIPTION
## Summary

- Bump version to 1.3.0
- Update CHANGELOG with decode_lossy performance improvements (1.5-2x for incomplete codepages)