### PR TITLE
ci: add benchmark job with gh-pages storage

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -76,15 +76,46 @@ jobs:
             exit 1
           fi
 
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v21
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
+
+      - name: Run benchmarks
+        run: nix develop --command cargo bench -- --noplot --output-format bencher | tee benchmark-results.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Yore Benchmarks
+          tool: 'cargo'
+          output-file-path: benchmark-results.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          alert-threshold: '110%'
+          fail-on-alert: true
+          fail-threshold: '120%'
+          comment-on-alert: true
+          comment-always: ${{ github.event_name == 'pull_request' }}
+          benchmark-data-dir-path: dev/bench
+
   # Final job that depends on all other jobs - use this in branch protection rules
   ci-success:
     runs-on: ubuntu-latest
-    needs: [build-and-test, fuzz, codegen]
+    needs: [build-and-test, fuzz, codegen, benchmark]
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
-          if [[ "${{ needs.build-and-test.result }}" != "success" || "${{ needs.fuzz.result }}" != "success" || "${{ needs.codegen.result }}" != "success" ]]; then
+          if [[ "${{ needs.build-and-test.result }}" != "success" || "${{ needs.fuzz.result }}" != "success" || "${{ needs.codegen.result }}" != "success" || "${{ needs.benchmark.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Add benchmark job to CI workflow using `benchmark-action/github-action-benchmark@v1`
- Store benchmark results in gh-pages branch for tracking over time
- Alert on >10% regression, fail on >20%
- Auto-push results on master, comment comparisons on PRs

## Test plan
- [ ] Configure repo permissions: Settings > Actions > General > "Read and write permissions"
- [ ] Verify benchmark job runs successfully
- [ ] Optionally enable GitHub Pages to view charts at `https://bonega.github.io/yore/dev/bench/`