### PR TITLE
Remove thiserror dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-06-09
+- Remove `thiserror` dependency in favor of hand-written error impls, making yore dependency-free. No API changes.
+
 ## [1.3.0] - 2026-01-10
 - Improve `decode_lossy` performance by 1.5-2x for incomplete codepages using dual-table approach
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yore"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Andreas Liljeqvist <bonega@gmail.com>"]
 edition = "2021"
 categories = ["encoding"]
@@ -12,7 +12,6 @@ repository = "https://github.com/bonega/yore/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0.25"
 
 [lib]
 bench = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,21 @@
 use std::borrow::Cow;
-
-use thiserror::Error;
+use std::fmt;
 
 pub mod code_pages;
 pub(crate) mod decoder;
 mod encoder;
 pub(crate) use encoder::Encoder;
 
-#[derive(Error, Debug)]
-#[error("Character in UTF-8 string has no mapping defined in code page")]
+#[derive(Debug)]
 pub struct EncodeError {}
+
+impl fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Character in UTF-8 string has no mapping defined in code page")
+    }
+}
+
+impl std::error::Error for EncodeError {}
 
 pub trait CodePage: Encoder {
     /// Encode UTF-8 string into single-byte encoding
@@ -107,12 +113,23 @@ pub trait CodePage: Encoder {
     }
 }
 
-#[derive(Error, Debug)]
-#[error("Undefined codepoint {value} at offset {position}")]
+#[derive(Debug)]
 pub struct DecodeError {
     pub position: usize,
     pub value: u8,
 }
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Undefined codepoint {} at offset {}",
+            self.value, self.position
+        )
+    }
+}
+
+impl std::error::Error for DecodeError {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- Replace `thiserror`'s `#[derive(Error)]` on `EncodeError` and `DecodeError` with hand-written `Display` + `std::error::Error` impls
- Remove the `thiserror` dependency from `Cargo.toml`, making `yore` dependency-free
- Bump version `1.3.0` → `1.3.1` and add a CHANGELOG entry

## Why
`yore` only used `thiserror` for `Display`/`Error` on two trivial error types — no `#[from]`, `#[source]`, or source chaining. Hand-writing the ~15 lines of impls drops the `thiserror`/`syn`/`quote`/`proc-macro2` build-time dependency tree. A dependency-free leaf encoding crate is a nice property for downstream consumers.

## Compatibility
Non-breaking patch release:
- Struct names, paths, and public fields are unchanged
- The same traits are implemented (`Debug`/`Display`/`Error`)
- Error message text is byte-for-byte identical
- `thiserror` was not re-exported, so dropping the dep is invisible to consumers

## Testing
- `cargo build` clean
- `cargo test`: 2 unit + 94 doc tests pass (including doc tests that pattern-match `DecodeError { position, value }`)