### PR TITLE
docs: update version references from 1.3.0 to 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Rust library for decoding and encoding character sets based on OEM code pages.
 
-[![yore at crates.io](https://img.shields.io/badge/crates.io-1.3.0-blue)](https://crates.io/crates/yore)
+[![yore at crates.io](https://img.shields.io/badge/crates.io-1.3.1-blue)](https://crates.io/crates/yore)
 [![yore at docs.rs](https://docs.rs/yore/badge.svg)](https://docs.rs/yore)
 
 # Features
@@ -18,7 +18,7 @@ Add `yore` to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-yore = "1.3.0"
+yore = "1.3.1"
 ```
 
 # Examples


### PR DESCRIPTION
When bumping for the 1.3.1 release, the version references in `README.md` were missed.

- Update crates.io badge: 1.3.0 → 1.3.1
- Update `Cargo.toml` dependency example: 1.3.0 → 1.3.1

The `CHANGELOG.md` `[1.3.0]` entry is left as-is (historical record); a `[1.3.1]` entry already exists.