### PR TITLE
ci: remove noisy benchmark job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -76,46 +76,15 @@ jobs:
             exit 1
           fi
 
-  benchmark:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v21
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-        with:
-          use-flakehub: false
-
-      - name: Run benchmarks
-        run: nix develop --command cargo bench -- --noplot --output-format bencher | tee benchmark-results.txt
-
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Yore Benchmarks
-          tool: 'cargo'
-          output-file-path: benchmark-results.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-          alert-threshold: '110%'
-          fail-on-alert: true
-          fail-threshold: '130%'
-          comment-on-alert: true
-          comment-always: ${{ github.event_name == 'pull_request' }}
-          benchmark-data-dir-path: dev/bench
-
   # Final job that depends on all other jobs - use this in branch protection rules
   ci-success:
     runs-on: ubuntu-latest
-    needs: [build-and-test, fuzz, codegen, benchmark]
+    needs: [build-and-test, fuzz, codegen]
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
-          if [[ "${{ needs.build-and-test.result }}" != "success" || "${{ needs.fuzz.result }}" != "success" || "${{ needs.codegen.result }}" != "success" || "${{ needs.benchmark.result }}" != "success" ]]; then
+          if [[ "${{ needs.build-and-test.result }}" != "success" || "${{ needs.fuzz.result }}" != "success" || "${{ needs.codegen.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi


### PR DESCRIPTION
Removes the `benchmark` CI job from `.github/workflows/nix.yml` — it was too noisy.

- Drops the `benchmark` job (cargo bench + github-action-benchmark storage to `dev/bench`).
- Removes `benchmark` from the `ci-success` job's `needs` list and pass-check.

Historical benchmark data on the gh-pages branch is left untouched.