### PR TITLE
perf: speed up decode_byte; add benchmark + differential fuzzer

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -71,6 +71,11 @@ jobs:
           cd fuzz
           nix develop --command cargo fuzz run invariant -- -max_total_time=60
 
+      - name: Fuzz decode_byte target
+        run: |
+          cd fuzz
+          nix develop --command cargo fuzz run decode_byte -- -max_total_time=60
+
   format:
     runs-on: ubuntu-latest
     steps:

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use criterion::{
-    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion,
-    Throughput,
+    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
+    Criterion, Throughput,
 };
 use rand::distributions::uniform::SampleRange;
 use rand::distributions::{Distribution, WeightedIndex};
@@ -10,7 +10,7 @@ use rand::distributions::{Distribution, WeightedIndex};
 use rand::{RngCore, SeedableRng};
 use rand_pcg::{Lcg128Xsl64, Pcg64};
 
-use yore::code_pages::CP874;
+use yore::code_pages::{CP437, CP874};
 
 /// Configure benchmark timing based on input size.
 /// Smaller inputs need less time since they run many more iterations.
@@ -105,6 +105,50 @@ fn decode_lossy(
     group.finish();
 }
 
+/// Per-byte allocation-free decoding. CP437 is a complete codepage
+/// (`decode_byte -> char`); CP874 is incomplete (`-> Option<char>`).
+/// Inputs span the full 0..=255 range to exercise 1/2/3-byte mappings.
+fn decode_byte(c: &mut Criterion) {
+    let mut rng_yore = Pcg64::seed_from_u64(42);
+    let mut group = c.benchmark_group("decode_byte");
+    for size in [256usize, 4096] {
+        configure_for_size(&mut group, size);
+        let input: Vec<u8> = (0..size).map(|_| rng_yore.next_u32() as u8).collect();
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("complete_cp437", size),
+            &input,
+            |b, input| {
+                b.iter(|| {
+                    let mut acc = 0u32;
+                    for &byte in input {
+                        acc = acc.wrapping_add(CP437.decode_byte(black_box(byte)) as u32);
+                    }
+                    acc
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("incomplete_cp874", size),
+            &input,
+            |b, input| {
+                b.iter(|| {
+                    let mut acc = 0u32;
+                    for &byte in input {
+                        if let Some(ch) = CP874.decode_byte(black_box(byte)) {
+                            acc = acc.wrapping_add(ch as u32);
+                        }
+                    }
+                    acc
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
 fn sample_mostly_ascii_bytes(rng: &mut impl RngCore, n: usize) -> Vec<u8> {
     let choices = [65, 161];
     let weights = [9, 1];
@@ -150,6 +194,7 @@ fn all_bad_strings(_rng: &mut impl RngCore, n: usize) -> String {
 fn bench(c: &mut Criterion) {
     const KB: usize = 1024;
     let sizes = &[8, 64, 256, 512, KB, 2 * KB, 4 * KB];
+    decode_byte(c);
     decode_checked(
         c,
         "decode_checked/mostly_ascii",

--- a/codegen/src/codegen_helper/templates/complete.rs
+++ b/codegen/src/codegen_helper/templates/complete.rs
@@ -47,12 +47,21 @@ impl CODERSTRUCT {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CODERSTRUCT byte-encoding

--- a/codegen/src/codegen_helper/templates/incomplete.rs
+++ b/codegen/src/codegen_helper/templates/incomplete.rs
@@ -84,10 +84,21 @@ impl CODERSTRUCT {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        let entry = DECODE_TABLE[b as usize]?;
-        // SAFETY: table contents are valid UTF-8 by construction.
-        let s = unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) };
-        s.chars().next()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize]?;
+        let cp = match e.len as u32 {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        Some(unsafe { char::from_u32_unchecked(cp) })
     }
 
     /// Encode UTF-8 string into CODERSTRUCT byte-encoding

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,3 +31,8 @@ name = "invariant"
 path = "fuzz_targets/invariant.rs"
 test = false
 doc = false
+[[bin]]
+name = "decode_byte"
+path = "fuzz_targets/decode_byte.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/decode_byte.rs
+++ b/fuzz/fuzz_targets/decode_byte.rs
@@ -1,0 +1,106 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use yore::code_pages::*;
+use yore::DecodeError;
+
+// Differential oracle: the allocation-free per-byte `decode_byte` must agree
+// with yore's own (heavily fuzzed) bulk `decode`/`decode_lossy`. Both read the
+// same tables, so decoding byte-by-byte and concatenating must reproduce the
+// bulk result exactly.
+
+/// Complete codepage: `decode_byte(b) -> char`, bulk `decode` never errors.
+macro_rules! check_complete {
+    ($cp:expr, $data:expr) => {{
+        let built: String = $data.iter().map(|&b| $cp.decode_byte(b)).collect();
+        let bulk = $cp.decode($data);
+        assert_eq!(
+            built.as_str(),
+            &*bulk,
+            concat!(stringify!($cp), ": decode_byte chain != decode")
+        );
+    }};
+}
+
+/// Incomplete codepage: `decode_byte(b) -> Option<char>` (`None` = undefined).
+macro_rules! check_incomplete {
+    ($cp:expr, $data:expr) => {{
+        // Strict path: decode byte-by-byte, stopping at the first undefined byte,
+        // and compare against the checked bulk decoder.
+        let mut built = String::new();
+        let mut first_none = None;
+        for (i, &b) in $data.iter().enumerate() {
+            match $cp.decode_byte(b) {
+                Some(c) => built.push(c),
+                None => {
+                    first_none = Some(i);
+                    break;
+                }
+            }
+        }
+        match ($cp.decode($data), first_none) {
+            (Ok(s), None) => assert_eq!(
+                built.as_str(),
+                &*s,
+                concat!(stringify!($cp), ": decode_byte chain != decode")
+            ),
+            (Err(DecodeError { position, .. }), Some(i)) => assert_eq!(
+                position, i,
+                concat!(
+                    stringify!($cp),
+                    ": decode_byte first None != decode error position"
+                )
+            ),
+            (bulk, fb) => panic!(
+                concat!(
+                    stringify!($cp),
+                    ": decode_byte/decode disagree (bulk {:?}, first None {:?})"
+                ),
+                bulk.map(|c| c.into_owned()),
+                fb
+            ),
+        }
+
+        // Lossy path: undefined bytes become the replacement char, matching
+        // `decode_lossy`.
+        let lossy: String = $data
+            .iter()
+            .map(|&b| $cp.decode_byte(b).unwrap_or('\u{FFFD}'))
+            .collect();
+        assert_eq!(
+            lossy.as_str(),
+            &*$cp.decode_lossy($data),
+            concat!(stringify!($cp), ": decode_byte lossy chain != decode_lossy")
+        );
+    }};
+}
+
+fuzz_target!(|data: &[u8]| {
+    // 18 complete codepages
+    check_complete!(CP437, data);
+    check_complete!(CP737, data);
+    check_complete!(CP850, data);
+    check_complete!(CP852, data);
+    check_complete!(CP855, data);
+    check_complete!(CP860, data);
+    check_complete!(CP861, data);
+    check_complete!(CP862, data);
+    check_complete!(CP863, data);
+    check_complete!(CP865, data);
+    check_complete!(CP866, data);
+    check_complete!(CP910, data);
+    check_complete!(CP1250, data);
+    check_complete!(CP1251, data);
+    check_complete!(CP1252, data);
+    check_complete!(CP1254, data);
+    check_complete!(CP1256, data);
+    check_complete!(CP1258, data);
+
+    // 7 incomplete codepages
+    check_incomplete!(CP857, data);
+    check_incomplete!(CP864, data);
+    check_incomplete!(CP869, data);
+    check_incomplete!(CP874, data);
+    check_incomplete!(CP1253, data);
+    check_incomplete!(CP1255, data);
+    check_incomplete!(CP1257, data);
+});

--- a/src/code_pages/cp1250.rs
+++ b/src/code_pages/cp1250.rs
@@ -49,12 +49,21 @@ impl CP1250 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP1250 byte-encoding

--- a/src/code_pages/cp1251.rs
+++ b/src/code_pages/cp1251.rs
@@ -49,12 +49,21 @@ impl CP1251 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP1251 byte-encoding

--- a/src/code_pages/cp1252.rs
+++ b/src/code_pages/cp1252.rs
@@ -49,12 +49,21 @@ impl CP1252 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP1252 byte-encoding

--- a/src/code_pages/cp1253.rs
+++ b/src/code_pages/cp1253.rs
@@ -86,10 +86,21 @@ impl CP1253 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        let entry = DECODE_TABLE[b as usize]?;
-        // SAFETY: table contents are valid UTF-8 by construction.
-        let s = unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) };
-        s.chars().next()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize]?;
+        let cp = match e.len as u32 {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        Some(unsafe { char::from_u32_unchecked(cp) })
     }
 
     /// Encode UTF-8 string into CP1253 byte-encoding

--- a/src/code_pages/cp1254.rs
+++ b/src/code_pages/cp1254.rs
@@ -49,12 +49,21 @@ impl CP1254 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP1254 byte-encoding

--- a/src/code_pages/cp1255.rs
+++ b/src/code_pages/cp1255.rs
@@ -86,10 +86,21 @@ impl CP1255 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        let entry = DECODE_TABLE[b as usize]?;
-        // SAFETY: table contents are valid UTF-8 by construction.
-        let s = unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) };
-        s.chars().next()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize]?;
+        let cp = match e.len as u32 {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        Some(unsafe { char::from_u32_unchecked(cp) })
     }
 
     /// Encode UTF-8 string into CP1255 byte-encoding

--- a/src/code_pages/cp1256.rs
+++ b/src/code_pages/cp1256.rs
@@ -49,12 +49,21 @@ impl CP1256 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP1256 byte-encoding

--- a/src/code_pages/cp1257.rs
+++ b/src/code_pages/cp1257.rs
@@ -86,10 +86,21 @@ impl CP1257 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        let entry = DECODE_TABLE[b as usize]?;
-        // SAFETY: table contents are valid UTF-8 by construction.
-        let s = unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) };
-        s.chars().next()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize]?;
+        let cp = match e.len as u32 {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        Some(unsafe { char::from_u32_unchecked(cp) })
     }
 
     /// Encode UTF-8 string into CP1257 byte-encoding

--- a/src/code_pages/cp1258.rs
+++ b/src/code_pages/cp1258.rs
@@ -49,12 +49,21 @@ impl CP1258 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP1258 byte-encoding

--- a/src/code_pages/cp437.rs
+++ b/src/code_pages/cp437.rs
@@ -49,12 +49,21 @@ impl CP437 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP437 byte-encoding

--- a/src/code_pages/cp737.rs
+++ b/src/code_pages/cp737.rs
@@ -49,12 +49,21 @@ impl CP737 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP737 byte-encoding

--- a/src/code_pages/cp850.rs
+++ b/src/code_pages/cp850.rs
@@ -49,12 +49,21 @@ impl CP850 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP850 byte-encoding

--- a/src/code_pages/cp852.rs
+++ b/src/code_pages/cp852.rs
@@ -49,12 +49,21 @@ impl CP852 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP852 byte-encoding

--- a/src/code_pages/cp855.rs
+++ b/src/code_pages/cp855.rs
@@ -49,12 +49,21 @@ impl CP855 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP855 byte-encoding

--- a/src/code_pages/cp857.rs
+++ b/src/code_pages/cp857.rs
@@ -86,10 +86,21 @@ impl CP857 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        let entry = DECODE_TABLE[b as usize]?;
-        // SAFETY: table contents are valid UTF-8 by construction.
-        let s = unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) };
-        s.chars().next()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize]?;
+        let cp = match e.len as u32 {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        Some(unsafe { char::from_u32_unchecked(cp) })
     }
 
     /// Encode UTF-8 string into CP857 byte-encoding

--- a/src/code_pages/cp860.rs
+++ b/src/code_pages/cp860.rs
@@ -49,12 +49,21 @@ impl CP860 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP860 byte-encoding

--- a/src/code_pages/cp861.rs
+++ b/src/code_pages/cp861.rs
@@ -49,12 +49,21 @@ impl CP861 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP861 byte-encoding

--- a/src/code_pages/cp862.rs
+++ b/src/code_pages/cp862.rs
@@ -49,12 +49,21 @@ impl CP862 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP862 byte-encoding

--- a/src/code_pages/cp863.rs
+++ b/src/code_pages/cp863.rs
@@ -49,12 +49,21 @@ impl CP863 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP863 byte-encoding

--- a/src/code_pages/cp864.rs
+++ b/src/code_pages/cp864.rs
@@ -87,10 +87,21 @@ impl CP864 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        let entry = DECODE_TABLE[b as usize]?;
-        // SAFETY: table contents are valid UTF-8 by construction.
-        let s = unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) };
-        s.chars().next()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize]?;
+        let cp = match e.len as u32 {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        Some(unsafe { char::from_u32_unchecked(cp) })
     }
 
     /// Encode UTF-8 string into CP864 byte-encoding

--- a/src/code_pages/cp865.rs
+++ b/src/code_pages/cp865.rs
@@ -49,12 +49,21 @@ impl CP865 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP865 byte-encoding

--- a/src/code_pages/cp866.rs
+++ b/src/code_pages/cp866.rs
@@ -49,12 +49,21 @@ impl CP866 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP866 byte-encoding

--- a/src/code_pages/cp869.rs
+++ b/src/code_pages/cp869.rs
@@ -86,10 +86,21 @@ impl CP869 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        let entry = DECODE_TABLE[b as usize]?;
-        // SAFETY: table contents are valid UTF-8 by construction.
-        let s = unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) };
-        s.chars().next()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize]?;
+        let cp = match e.len as u32 {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        Some(unsafe { char::from_u32_unchecked(cp) })
     }
 
     /// Encode UTF-8 string into CP869 byte-encoding

--- a/src/code_pages/cp874.rs
+++ b/src/code_pages/cp874.rs
@@ -86,10 +86,21 @@ impl CP874 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        let entry = DECODE_TABLE[b as usize]?;
-        // SAFETY: table contents are valid UTF-8 by construction.
-        let s = unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) };
-        s.chars().next()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize]?;
+        let cp = match e.len as u32 {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        Some(unsafe { char::from_u32_unchecked(cp) })
     }
 
     /// Encode UTF-8 string into CP874 byte-encoding

--- a/src/code_pages/cp910.rs
+++ b/src/code_pages/cp910.rs
@@ -49,12 +49,21 @@ impl CP910 {
     /// ```
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        let entry = DECODE_TABLE[b as usize];
-        // SAFETY: table contents are valid UTF-8 by construction.
-        unsafe { core::str::from_utf8_unchecked(&entry.buf[..entry.len as usize]) }
-            .chars()
-            .next()
-            .unwrap()
+        // Decode the entry's stored UTF-8 bytes back into their scalar value,
+        // using the length we already have. Reading the fields directly (rather
+        // than passing `buf` to a helper) lets the entry load as a single word.
+        let e = DECODE_TABLE[b as usize];
+        let cp = match e.len {
+            1 => e.buf[0] as u32,
+            2 => ((e.buf[0] as u32 & 0x1F) << 6) | (e.buf[1] as u32 & 0x3F),
+            _ => {
+                ((e.buf[0] as u32 & 0x0F) << 12)
+                    | ((e.buf[1] as u32 & 0x3F) << 6)
+                    | (e.buf[2] as u32 & 0x3F)
+            }
+        };
+        // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     /// Encode UTF-8 string into CP910 byte-encoding


### PR DESCRIPTION
## Summary
Faster `decode_byte`, plus a benchmark and a fuzzer that guard it.

Decode a table entry's stored UTF-8 bytes straight to a scalar value using the length already in the entry, instead of `from_utf8_unchecked(..).chars().next().unwrap()`. The old form re-derived the UTF-8 length from the leading byte and carried two panic landing pads the compiler can't elide (the `&buf[..len]` slice bound and the `unwrap`). Reading the entry's fields directly lets it load as a single word, with no panic paths.

## Benchmark (criterion, vs the current implementation)

| codepage | 256 B | 4096 B |
|---|---|---|
| complete (CP437) | −18% | −14% |
| incomplete (CP874) | −32% | −24% |

A `decode_byte` benchmark group (complete CP437 + incomplete CP874, full `0..=255` input range) is added so the primitive stays tracked.

## Fuzzer
New `decode_byte` fuzz target: a **differential oracle** that checks the allocation-free per-byte primitive against yore's own (already fuzzed) bulk `decode`/`decode_lossy` across all 25 codepages — strict path (string + error position) and lossy path. They share only the tables, not the decode logic, so any divergence in the mask/shift math is caught. Verified it catches a deliberately corrupted strip mask. Wired into the CI fuzz job (60s).

## Notes
- Pure perf + test change; no public API change. Codegen templates updated and all 25 pages regenerated (codegen is idempotent + fmt-clean).
- No version bump included — happy to add a `CHANGELOG`/patch-release entry if you want this in a release.

## Test plan
- [x] `cargo test` (144 pass)
- [x] `cargo clippy --all-targets` + no-alloc & alloc reduced sets, `-D warnings`
- [x] bare-metal `thumbv7em-none-eabi` builds (no-alloc and alloc)
- [x] `cargo fuzz run decode_byte` clean (~312k execs); catches an injected mask bug