### PR TITLE
perf: store codepoints in the no-alloc decode table

### DIFF
--- a/codegen/src/codegen_helper/templates/complete.rs
+++ b/codegen/src/codegen_helper/templates/complete.rs
@@ -45,11 +45,12 @@ impl CODERSTRUCT {
     ///
     /// assert_eq!(CODERSTRUCT.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -62,6 +63,15 @@ impl CODERSTRUCT {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CODERSTRUCT byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CODERSTRUCT byte-encoding
@@ -130,3 +140,18 @@ impl CodePage for CODERSTRUCT {
 }
 
 const DECODE_TABLE: decoder::complete::Table = PLACEHOLDER_TABLE;
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};

--- a/codegen/src/codegen_helper/templates/incomplete.rs
+++ b/codegen/src/codegen_helper/templates/incomplete.rs
@@ -82,11 +82,12 @@ impl CODERSTRUCT {
     ///
     /// assert_eq!(CODERSTRUCT.decode_byte(b't'), Some('t'));
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize]?;
         let cp = match e.len as u32 {
             1 => e.buf[0] as u32,
@@ -99,6 +100,16 @@ impl CODERSTRUCT {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         Some(unsafe { char::from_u32_unchecked(cp) })
+    }
+
+    /// Decode a single CODERSTRUCT byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> Option<char> {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (`Option<char>` niche-packs to the same 4 bytes/entry) and
+        // this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CODERSTRUCT byte-encoding
@@ -188,3 +199,21 @@ impl CodePage for CODERSTRUCT {
 const DECODE_TABLE: decoder::incomplete::Table = PLACEHOLDER_TABLE;
 #[cfg(feature = "alloc")]
 const DECODE_TABLE_LOSSY: decoder::complete::Table = PLACEHOLDER_LOSSY_TABLE;
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size,
+// `Option<char>` niche-packs to 4 bytes/entry) takes its place in rodata and
+// makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [Option<char>; 256] = {
+    let mut t = [None; 256];
+    let mut i = 0;
+    while i < 256 {
+        t[i] = match DECODE_TABLE[i] {
+            Some(e) => Some(decoder::entry_to_char(e.buf, e.len as u32)),
+            None => None,
+        };
+        i += 1;
+    }
+    t
+};

--- a/src/code_pages/cp1250.rs
+++ b/src/code_pages/cp1250.rs
@@ -47,11 +47,12 @@ impl CP1250 {
     ///
     /// assert_eq!(CP1250.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP1250 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP1250 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP1250 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP1250 {
     #[doc(hidden)]

--- a/src/code_pages/cp1251.rs
+++ b/src/code_pages/cp1251.rs
@@ -47,11 +47,12 @@ impl CP1251 {
     ///
     /// assert_eq!(CP1251.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP1251 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP1251 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP1251 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP1251 {
     #[doc(hidden)]

--- a/src/code_pages/cp1252.rs
+++ b/src/code_pages/cp1252.rs
@@ -47,11 +47,12 @@ impl CP1252 {
     ///
     /// assert_eq!(CP1252.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP1252 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP1252 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP1252 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP1252 {
     #[doc(hidden)]

--- a/src/code_pages/cp1253.rs
+++ b/src/code_pages/cp1253.rs
@@ -84,11 +84,12 @@ impl CP1253 {
     ///
     /// assert_eq!(CP1253.decode_byte(b't'), Some('t'));
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize]?;
         let cp = match e.len as u32 {
             1 => e.buf[0] as u32,
@@ -101,6 +102,16 @@ impl CP1253 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         Some(unsafe { char::from_u32_unchecked(cp) })
+    }
+
+    /// Decode a single CP1253 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> Option<char> {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (`Option<char>` niche-packs to the same 4 bytes/entry) and
+        // this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP1253 byte-encoding
@@ -2231,6 +2242,24 @@ const DECODE_TABLE_LOSSY: decoder::complete::Table = [
         len: 3,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size,
+// `Option<char>` niche-packs to 4 bytes/entry) takes its place in rodata and
+// makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [Option<char>; 256] = {
+    let mut t = [None; 256];
+    let mut i = 0;
+    while i < 256 {
+        t[i] = match DECODE_TABLE[i] {
+            Some(e) => Some(decoder::entry_to_char(e.buf, e.len as u32)),
+            None => None,
+        };
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP1253 {
     #[doc(hidden)]

--- a/src/code_pages/cp1254.rs
+++ b/src/code_pages/cp1254.rs
@@ -47,11 +47,12 @@ impl CP1254 {
     ///
     /// assert_eq!(CP1254.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP1254 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP1254 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP1254 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP1254 {
     #[doc(hidden)]

--- a/src/code_pages/cp1255.rs
+++ b/src/code_pages/cp1255.rs
@@ -84,11 +84,12 @@ impl CP1255 {
     ///
     /// assert_eq!(CP1255.decode_byte(b't'), Some('t'));
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize]?;
         let cp = match e.len as u32 {
             1 => e.buf[0] as u32,
@@ -101,6 +102,16 @@ impl CP1255 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         Some(unsafe { char::from_u32_unchecked(cp) })
+    }
+
+    /// Decode a single CP1255 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> Option<char> {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (`Option<char>` niche-packs to the same 4 bytes/entry) and
+        // this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP1255 byte-encoding
@@ -2210,6 +2221,24 @@ const DECODE_TABLE_LOSSY: decoder::complete::Table = [
         len: 3,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size,
+// `Option<char>` niche-packs to 4 bytes/entry) takes its place in rodata and
+// makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [Option<char>; 256] = {
+    let mut t = [None; 256];
+    let mut i = 0;
+    while i < 256 {
+        t[i] = match DECODE_TABLE[i] {
+            Some(e) => Some(decoder::entry_to_char(e.buf, e.len as u32)),
+            None => None,
+        };
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP1255 {
     #[doc(hidden)]

--- a/src/code_pages/cp1256.rs
+++ b/src/code_pages/cp1256.rs
@@ -47,11 +47,12 @@ impl CP1256 {
     ///
     /// assert_eq!(CP1256.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP1256 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP1256 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP1256 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP1256 {
     #[doc(hidden)]

--- a/src/code_pages/cp1257.rs
+++ b/src/code_pages/cp1257.rs
@@ -84,11 +84,12 @@ impl CP1257 {
     ///
     /// assert_eq!(CP1257.decode_byte(b't'), Some('t'));
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize]?;
         let cp = match e.len as u32 {
             1 => e.buf[0] as u32,
@@ -101,6 +102,16 @@ impl CP1257 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         Some(unsafe { char::from_u32_unchecked(cp) })
+    }
+
+    /// Decode a single CP1257 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> Option<char> {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (`Option<char>` niche-packs to the same 4 bytes/entry) and
+        // this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP1257 byte-encoding
@@ -2234,6 +2245,24 @@ const DECODE_TABLE_LOSSY: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size,
+// `Option<char>` niche-packs to 4 bytes/entry) takes its place in rodata and
+// makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [Option<char>; 256] = {
+    let mut t = [None; 256];
+    let mut i = 0;
+    while i < 256 {
+        t[i] = match DECODE_TABLE[i] {
+            Some(e) => Some(decoder::entry_to_char(e.buf, e.len as u32)),
+            None => None,
+        };
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP1257 {
     #[doc(hidden)]

--- a/src/code_pages/cp1258.rs
+++ b/src/code_pages/cp1258.rs
@@ -47,11 +47,12 @@ impl CP1258 {
     ///
     /// assert_eq!(CP1258.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP1258 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP1258 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP1258 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP1258 {
     #[doc(hidden)]

--- a/src/code_pages/cp437.rs
+++ b/src/code_pages/cp437.rs
@@ -47,11 +47,12 @@ impl CP437 {
     ///
     /// assert_eq!(CP437.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP437 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP437 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP437 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP437 {
     #[doc(hidden)]

--- a/src/code_pages/cp737.rs
+++ b/src/code_pages/cp737.rs
@@ -47,11 +47,12 @@ impl CP737 {
     ///
     /// assert_eq!(CP737.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP737 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP737 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP737 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP737 {
     #[doc(hidden)]

--- a/src/code_pages/cp850.rs
+++ b/src/code_pages/cp850.rs
@@ -47,11 +47,12 @@ impl CP850 {
     ///
     /// assert_eq!(CP850.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP850 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP850 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP850 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP850 {
     #[doc(hidden)]

--- a/src/code_pages/cp852.rs
+++ b/src/code_pages/cp852.rs
@@ -47,11 +47,12 @@ impl CP852 {
     ///
     /// assert_eq!(CP852.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP852 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP852 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP852 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP852 {
     #[doc(hidden)]

--- a/src/code_pages/cp855.rs
+++ b/src/code_pages/cp855.rs
@@ -47,11 +47,12 @@ impl CP855 {
     ///
     /// assert_eq!(CP855.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP855 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP855 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP855 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP855 {
     #[doc(hidden)]

--- a/src/code_pages/cp857.rs
+++ b/src/code_pages/cp857.rs
@@ -84,11 +84,12 @@ impl CP857 {
     ///
     /// assert_eq!(CP857.decode_byte(b't'), Some('t'));
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize]?;
         let cp = match e.len as u32 {
             1 => e.buf[0] as u32,
@@ -101,6 +102,16 @@ impl CP857 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         Some(unsafe { char::from_u32_unchecked(cp) })
+    }
+
+    /// Decode a single CP857 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> Option<char> {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (`Option<char>` niche-packs to the same 4 bytes/entry) and
+        // this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP857 byte-encoding
@@ -2231,6 +2242,24 @@ const DECODE_TABLE_LOSSY: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size,
+// `Option<char>` niche-packs to 4 bytes/entry) takes its place in rodata and
+// makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [Option<char>; 256] = {
+    let mut t = [None; 256];
+    let mut i = 0;
+    while i < 256 {
+        t[i] = match DECODE_TABLE[i] {
+            Some(e) => Some(decoder::entry_to_char(e.buf, e.len as u32)),
+            None => None,
+        };
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP857 {
     #[doc(hidden)]

--- a/src/code_pages/cp860.rs
+++ b/src/code_pages/cp860.rs
@@ -47,11 +47,12 @@ impl CP860 {
     ///
     /// assert_eq!(CP860.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP860 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP860 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP860 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP860 {
     #[doc(hidden)]

--- a/src/code_pages/cp861.rs
+++ b/src/code_pages/cp861.rs
@@ -47,11 +47,12 @@ impl CP861 {
     ///
     /// assert_eq!(CP861.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP861 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP861 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP861 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP861 {
     #[doc(hidden)]

--- a/src/code_pages/cp862.rs
+++ b/src/code_pages/cp862.rs
@@ -47,11 +47,12 @@ impl CP862 {
     ///
     /// assert_eq!(CP862.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP862 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP862 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP862 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP862 {
     #[doc(hidden)]

--- a/src/code_pages/cp863.rs
+++ b/src/code_pages/cp863.rs
@@ -47,11 +47,12 @@ impl CP863 {
     ///
     /// assert_eq!(CP863.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP863 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP863 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP863 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP863 {
     #[doc(hidden)]

--- a/src/code_pages/cp864.rs
+++ b/src/code_pages/cp864.rs
@@ -85,11 +85,12 @@ impl CP864 {
     ///
     /// assert_eq!(CP864.decode_byte(b't'), Some('t'));
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize]?;
         let cp = match e.len as u32 {
             1 => e.buf[0] as u32,
@@ -102,6 +103,16 @@ impl CP864 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         Some(unsafe { char::from_u32_unchecked(cp) })
+    }
+
+    /// Decode a single CP864 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> Option<char> {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (`Option<char>` niche-packs to the same 4 bytes/entry) and
+        // this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP864 byte-encoding
@@ -2223,6 +2234,24 @@ const DECODE_TABLE_LOSSY: decoder::complete::Table = [
         len: 3,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size,
+// `Option<char>` niche-packs to 4 bytes/entry) takes its place in rodata and
+// makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [Option<char>; 256] = {
+    let mut t = [None; 256];
+    let mut i = 0;
+    while i < 256 {
+        t[i] = match DECODE_TABLE[i] {
+            Some(e) => Some(decoder::entry_to_char(e.buf, e.len as u32)),
+            None => None,
+        };
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP864 {
     #[doc(hidden)]

--- a/src/code_pages/cp865.rs
+++ b/src/code_pages/cp865.rs
@@ -47,11 +47,12 @@ impl CP865 {
     ///
     /// assert_eq!(CP865.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP865 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP865 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP865 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP865 {
     #[doc(hidden)]

--- a/src/code_pages/cp866.rs
+++ b/src/code_pages/cp866.rs
@@ -47,11 +47,12 @@ impl CP866 {
     ///
     /// assert_eq!(CP866.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP866 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP866 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP866 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP866 {
     #[doc(hidden)]

--- a/src/code_pages/cp869.rs
+++ b/src/code_pages/cp869.rs
@@ -84,11 +84,12 @@ impl CP869 {
     ///
     /// assert_eq!(CP869.decode_byte(b't'), Some('t'));
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize]?;
         let cp = match e.len as u32 {
             1 => e.buf[0] as u32,
@@ -101,6 +102,16 @@ impl CP869 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         Some(unsafe { char::from_u32_unchecked(cp) })
+    }
+
+    /// Decode a single CP869 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> Option<char> {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (`Option<char>` niche-packs to the same 4 bytes/entry) and
+        // this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP869 byte-encoding
@@ -2213,6 +2224,24 @@ const DECODE_TABLE_LOSSY: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size,
+// `Option<char>` niche-packs to 4 bytes/entry) takes its place in rodata and
+// makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [Option<char>; 256] = {
+    let mut t = [None; 256];
+    let mut i = 0;
+    while i < 256 {
+        t[i] = match DECODE_TABLE[i] {
+            Some(e) => Some(decoder::entry_to_char(e.buf, e.len as u32)),
+            None => None,
+        };
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP869 {
     #[doc(hidden)]

--- a/src/code_pages/cp874.rs
+++ b/src/code_pages/cp874.rs
@@ -84,11 +84,12 @@ impl CP874 {
     ///
     /// assert_eq!(CP874.decode_byte(b't'), Some('t'));
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> Option<char> {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize]?;
         let cp = match e.len as u32 {
             1 => e.buf[0] as u32,
@@ -101,6 +102,16 @@ impl CP874 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         Some(unsafe { char::from_u32_unchecked(cp) })
+    }
+
+    /// Decode a single CP874 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> Option<char> {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (`Option<char>` niche-packs to the same 4 bytes/entry) and
+        // this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP874 byte-encoding
@@ -2216,6 +2227,24 @@ const DECODE_TABLE_LOSSY: decoder::complete::Table = [
         len: 3,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size,
+// `Option<char>` niche-packs to 4 bytes/entry) takes its place in rodata and
+// makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [Option<char>; 256] = {
+    let mut t = [None; 256];
+    let mut i = 0;
+    while i < 256 {
+        t[i] = match DECODE_TABLE[i] {
+            Some(e) => Some(decoder::entry_to_char(e.buf, e.len as u32)),
+            None => None,
+        };
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP874 {
     #[doc(hidden)]

--- a/src/code_pages/cp910.rs
+++ b/src/code_pages/cp910.rs
@@ -47,11 +47,12 @@ impl CP910 {
     ///
     /// assert_eq!(CP910.decode_byte(b't'), 't');
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub fn decode_byte(self, b: u8) -> char {
-        // Decode the entry's stored UTF-8 bytes back into their scalar value,
-        // using the length we already have. Reading the fields directly (rather
-        // than passing `buf` to a helper) lets the entry load as a single word.
+        // The UTF-8 decode table is already in memory for the bulk `decode`
+        // path, so decode the entry's stored bytes from the length we have
+        // rather than carrying a second (codepoint) table.
         let e = DECODE_TABLE[b as usize];
         let cp = match e.len {
             1 => e.buf[0] as u32,
@@ -64,6 +65,15 @@ impl CP910 {
         };
         // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
         unsafe { char::from_u32_unchecked(cp) }
+    }
+
+    /// Decode a single CP910 byte into its character.
+    #[cfg(not(feature = "alloc"))]
+    #[inline(always)]
+    pub fn decode_byte(self, b: u8) -> char {
+        // No bulk decoder in this build, so the table stores codepoints
+        // directly (same 4 bytes/entry as the UTF-8 table) and this is a load.
+        DECODE_TABLE_CHAR[b as usize]
     }
 
     /// Encode UTF-8 string into CP910 byte-encoding
@@ -1157,6 +1167,21 @@ const DECODE_TABLE: decoder::complete::Table = [
         len: 2,
     },
 ];
+
+// In the no-alloc build there is no bulk decoder, so `DECODE_TABLE` is consumed
+// only by this const-eval and is never emitted; `DECODE_TABLE_CHAR` (same size)
+// takes its place in rodata and makes `decode_byte` a single load.
+#[cfg(not(feature = "alloc"))]
+const DECODE_TABLE_CHAR: [char; 256] = {
+    let mut t = ['\0'; 256];
+    let mut i = 0;
+    while i < 256 {
+        let e = DECODE_TABLE[i];
+        t[i] = decoder::entry_to_char(e.buf, e.len as u32);
+        i += 1;
+    }
+    t
+};
 
 impl Encoder for CP910 {
     #[doc(hidden)]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -11,6 +11,23 @@ use core::mem;
 pub(crate) use complete::Entry as CompleteEntry;
 pub(crate) use incomplete::{Entry as IncompleteEntry, Len as IncompleteLen};
 
+/// Decode a table entry's stored UTF-8 (1–3 bytes, known `len`) into its `char`.
+///
+/// Used only at const-eval time to build the no-alloc codepoint tables, so the
+/// per-byte cost is paid by the compiler, not at runtime.
+#[cfg(not(feature = "alloc"))]
+pub(crate) const fn entry_to_char(buf: [u8; 3], len: u32) -> char {
+    let cp = match len {
+        1 => buf[0] as u32,
+        2 => ((buf[0] as u32 & 0x1F) << 6) | (buf[1] as u32 & 0x3F),
+        _ => {
+            ((buf[0] as u32 & 0x0F) << 12) | ((buf[1] as u32 & 0x3F) << 6) | (buf[2] as u32 & 0x3F)
+        }
+    };
+    // SAFETY: table contents are valid UTF-8 for exactly one scalar value.
+    unsafe { char::from_u32_unchecked(cp) }
+}
+
 #[cfg(feature = "alloc")]
 const USIZE_SIZE: usize = mem::size_of::<usize>();
 


### PR DESCRIPTION
## Summary
In the **no-alloc** build there's no bulk decoder, so the UTF-8 decode table is only needed to derive a codepoint table at compile time. Store that table directly (`[char; 256]` / `[Option<char>; 256]`) and make `decode_byte` a single indexed load instead of decoding UTF-8 on every call. The `alloc` build is unchanged.

## Why it's free
- **Same size.** `char` and `Option<char>` are 4 bytes (niche-packed) — identical to the `Entry`/`Option<Entry>` they replace. The table stays 1 KiB.
- **Smaller code, not just faster.** The `match`/shift decode logic leaves `.text`, and the UTF-8 table is *replaced*, not added: it's consumed at const-eval and never emitted in this build.

## Verified
- **~2× faster** `decode_byte` (criterion):

  | | 256 B | 4096 B |
  |---|---|---|
  | complete (CP437) | −48% | −51% |
  | incomplete (CP874) | −44% | −50% |

- **Single load.** Under `--no-default-features`, both complete and incomplete `decode_byte` lower to `mov eax, [table + 4*rax]; ret`.
- **One table.** In a single-codepage no-alloc binary, rodata contains the codepoint-table entry for `0xDB` (`88 25 00 00` = U+2588) and **not** the UTF-8-entry signature (`e2 96 88 03`) — the UTF-8 table is gone.
- **Identical output.** The same crate built with and without `alloc` produces identical `decode_byte` results for all 256 bytes across a complete and an incomplete codepage.

## How
Only under `#[cfg(not(feature = "alloc"))]`: a `const DECODE_TABLE_CHAR` derived from the existing UTF-8 table via const-eval (`decoder::entry_to_char`), and `decode_byte` indexes it. Under `alloc`, `decode_byte` keeps the field-read form (the UTF-8 table is already in memory for bulk decode).

## Notes
- No public API change; the no-alloc and alloc tiers return the same values. No version bump included.
- Codegen templates updated and all 25 pages regenerated (idempotent + fmt-clean).

## Test plan
- [x] `cargo test` (144 pass)
- [x] clippy `-D warnings`: all-targets + no-alloc + alloc lib
- [x] bare-metal `thumbv7em-none-eabi` builds (no-alloc and alloc)
- [x] no-alloc vs alloc `decode_byte` output diff: identical