### PR TITLE
release: 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-06-14
+- Speed up the allocation-free `decode_byte` primitive (~2-4x) in `no_std`/no-allocator builds: the decode table now stores codepoints directly, so `decode_byte` lowers to a single indexed load. No API changes.
+
 ## [2.0.0] - 2026-06-13
 - Add allocation-free `encode_char` / `decode_byte` primitives, available without an allocator (e.g. for `no_std` embedded targets).
 - Add an `alloc` feature gating the `Cow`-returning `encode`/`decode` API. `std` now implies `alloc`, so the default build is unchanged.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yore"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Andreas Liljeqvist <bonega@gmail.com>"]
 edition = "2021"
 categories = ["encoding"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Rust library for decoding and encoding character sets based on OEM code pages.
 
-[![yore at crates.io](https://img.shields.io/badge/crates.io-2.0.0-blue)](https://crates.io/crates/yore)
+[![yore at crates.io](https://img.shields.io/badge/crates.io-2.0.1-blue)](https://crates.io/crates/yore)
 [![yore at docs.rs](https://docs.rs/yore/badge.svg)](https://docs.rs/yore)
 
 # Features
@@ -20,7 +20,7 @@ Add `yore` to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-yore = "2.0.0"
+yore = "2.0.1"
 ```
 
 ## `no_std`
@@ -41,10 +41,10 @@ requires the `alloc` feature. Without it, only the allocation-free
 ```toml
 [dependencies]
 # no_std with an allocator: keep the full Cow-returning API
-yore = { version = "2.0.0", default-features = false, features = ["alloc"] }
+yore = { version = "2.0.1", default-features = false, features = ["alloc"] }
 
 # no_std without an allocator: char primitives only
-yore = { version = "2.0.0", default-features = false }
+yore = { version = "2.0.1", default-features = false }
 ```
 
 ```rust


### PR DESCRIPTION
Patch release bundling the unreleased no-alloc `decode_byte` performance work.

## Changes
- **Cargo.toml**: `2.0.0` → `2.0.1`
- **CHANGELOG.md**: new `2.0.1` entry
- **README.md**: version references updated (crates.io badge + the three `Cargo.toml` snippets)

## What's in this release
Two perf-only commits already merged to `master` since 2.0.0, both pure speedups to the allocation-free `decode_byte` primitive with no API changes:
- #33 — store codepoints in the no-alloc decode table (`decode_byte` lowers to a single indexed load)
- #32 — speed up `decode_byte`; add benchmark + differential fuzzer

## Release steps after merge
Since this repo squash-merges, the tag should point at the squashed commit on `master`:
1. Merge this PR
2. `git tag v2.0.1` on the squashed `master` commit, push the tag
3. `cargo publish`